### PR TITLE
Fixed droppers

### DIFF
--- a/RedstoneCircuit/src/redstone/blocks/BlockDropper.php
+++ b/RedstoneCircuit/src/redstone/blocks/BlockDropper.php
@@ -7,6 +7,7 @@ use pocketmine\Player;
 use pocketmine\block\Block;
 use pocketmine\block\BlockToolType;
 use pocketmine\block\Solid;
+use pocketmine\item\TieredTool;
 
 use pocketmine\item\Item;
 


### PR DESCRIPTION
This issue was occurred when breaking droppers in survival. This has now been fixed. This issue closes #4 