### PR TITLE
Added `Cancellable` interface to event classes using `CancellableTrait`

### DIFF
--- a/src/tedo0627/redstonecircuit/event/BlockDispenseEvent.php
+++ b/src/tedo0627/redstonecircuit/event/BlockDispenseEvent.php
@@ -4,10 +4,11 @@ namespace tedo0627\redstonecircuit\event;
 
 use pocketmine\block\Block;
 use pocketmine\event\block\BlockEvent;
+use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\item\Item;
 
-class BlockDispenseEvent extends BlockEvent {
+class BlockDispenseEvent extends BlockEvent implements Cancellable {
     use CancellableTrait;
 
     private Item $item;

--- a/src/tedo0627/redstonecircuit/event/BlockPistonEvent.php
+++ b/src/tedo0627/redstonecircuit/event/BlockPistonEvent.php
@@ -3,10 +3,11 @@
 namespace tedo0627\redstonecircuit\event;
 
 use pocketmine\event\block\BlockEvent;
+use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use tedo0627\redstonecircuit\block\mechanism\BlockPiston;
 
-class BlockPistonEvent extends BlockEvent {
+class BlockPistonEvent extends BlockEvent implements Cancellable {
     use CancellableTrait;
 
     private BlockPiston $piston;

--- a/src/tedo0627/redstonecircuit/event/HopperMoveItemEvent.php
+++ b/src/tedo0627/redstonecircuit/event/HopperMoveItemEvent.php
@@ -5,11 +5,12 @@ namespace tedo0627\redstonecircuit\event;
 use pocketmine\block\Hopper;
 use pocketmine\block\Jukebox;
 use pocketmine\event\block\BlockEvent;
+use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\inventory\Inventory;
 use pocketmine\item\Item;
 
-class HopperMoveItemEvent extends BlockEvent {
+class HopperMoveItemEvent extends BlockEvent implements Cancellable {
     use CancellableTrait;
 
     private Hopper $hopper;

--- a/src/tedo0627/redstonecircuit/event/HopperPickupItemEvent.php
+++ b/src/tedo0627/redstonecircuit/event/HopperPickupItemEvent.php
@@ -5,11 +5,12 @@ namespace tedo0627\redstonecircuit\event;
 use pocketmine\block\Hopper;
 use pocketmine\entity\object\ItemEntity;
 use pocketmine\event\block\BlockEvent;
+use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\inventory\Inventory;
 use pocketmine\item\Item;
 
-class HopperPickupItemEvent extends BlockEvent {
+class HopperPickupItemEvent extends BlockEvent implements Cancellable {
     use CancellableTrait;
 
     private Hopper $hopper;


### PR DESCRIPTION
Currently, this plugin only uses PocketMine-MP's [`CancellableTrait`](https://github.com/pmmp/PocketMine-MP/blob/stable/src/event/CancellableTrait.php) to add methods like `cancel()` to its event classes to make them cancellable. 
But unlike the event classes of PocketMine-MP, it does not implement the [`Cancellable`](https://github.com/pmmp/PocketMine-MP/blob/stable/src/event/Cancellable.php) interface.

This is problematic because without this interface implemented, PMMP's internal event handlers won't know that those events are cancellable, which can be seen [here](https://github.com/pmmp/PocketMine-MP/blob/39b8daeeec3fd2ad9a8593bb15edca65349948bd/src/event/RegisteredListener.php#L70-L77).

Because of that, it is for example not possible to use PMMP's [`handleCancelled`](https://github.com/pmmp/PocketMine-MP/blob/39b8daeeec3fd2ad9a8593bb15edca65349948bd/src/event/ListenerMethodTags.php#L31) tag on handler methods to disable the calling of your listener if the event was already cancelled. This tag can only be used, if the event class you want to listen for, implements the `Cancellable` interface, which can be seen [here](https://github.com/pmmp/PocketMine-MP/blob/39b8daeeec3fd2ad9a8593bb15edca65349948bd/src/plugin/PluginManager.php#L557-L558).